### PR TITLE
Adding colon2 to Sexp#to_s

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "http://rubygems.org"
+gem 'rake'
 gemspec

--- a/lib/rails_best_practices/core/visitable_sexp.rb
+++ b/lib/rails_best_practices/core/visitable_sexp.rb
@@ -415,6 +415,8 @@ class Sexp
         key_value = !key_value
       end
       result.join("").sub(/, "$/, '') + '}'
+    elsif :colon2 == node_type
+      self[1].to_s + self[2].to_s
     end
   end
 end

--- a/spec/rails_best_practices/core/visitable_sexp_spec.rb
+++ b/spec/rails_best_practices/core/visitable_sexp_spec.rb
@@ -250,5 +250,10 @@ describe Sexp do
       node = @parser.parse("{:first_name => 'Richard', :last_name => 'Huang'}")
       node.to_s.should == '{"first_name" => "Richard", "last_name" => "Huang"}'
     end
+
+    it "should get to_s for colon2" do
+      node = @parser.parse("RailsBestPractices::Core")
+      node.to_s.should == "RailsBestPracticesCore"
+    end
   end
 end


### PR DESCRIPTION
The Sexp#to_s method was missing support for :colon2. This update will account for that by concatenating the constants.

spec tests have also been written and passes.
