### PR TITLE
do not suggest multipart/alternative when mixing haml/erb to create text and html email views

### DIFF
--- a/lib/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review.rb
+++ b/lib/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review.rb
@@ -54,13 +54,18 @@ module RailsBestPractices
         #
         # @param [String] name method name in action_mailer
         def rails3_canonical_mailer_views?(name)
-          (exist?("#{name}.html.erb") && !exist?("#{name}.text.erb")) ||
-          (exist?("#{name}.html.haml") && !exist?("#{name}.text.haml"))
+          (exist?("#{name}.html.erb") && !haml_or_erb_exists?("#{name}.text")) ||
+          (exist?("#{name}.html.haml") && !haml_or_erb_exists?("#{name}.text") )
         end
 
         # check if the filename existed in the mailer directory.
         def exist?(filename)
           File.exist? File.join(mailer_directory, filename)
+        end
+
+        # check if haml or erb exists
+        def haml_or_erb_exists?(filename)
+          exist?("#{filename}.erb") || exist?("#{filename}.haml")
         end
 
         # check if the method is a deliver_method.

--- a/spec/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review_spec.rb
+++ b/spec/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review_spec.rb
@@ -160,13 +160,25 @@ describe RailsBestPractices::Reviews::UseMultipartAlternativeAsContentTypeOfEmai
         end
 
         it "should not use multipart/alternative as content_type of email" do
-          mock_email_files(["send_email.html.haml"], "text.haml" => true, "html.haml" => true)
+          mock_email_files(["send_email.html.haml", "send_email.text.haml"], "html.haml" => true, "text.haml" => true)
           runner.review('app/mailers/project_mailer.rb', content)
           runner.should have(0).errors
         end
 
         it "should not use multiple/alternative as content_type of email when only plain text" do
           mock_email_files(["send_email.text.haml"], "text.haml" => true)
+          runner.review('app/mailers/project_mailer.rb', content)
+          runner.should have(0).errors
+        end
+      end
+
+      context "haml/erb mix" do
+        it "should not suggest using multipart/alternative when mixing html.haml and text.erb" do
+          mock_email_files(["send_email.html.haml", "send_email.text.erb"], "html.haml" => true, "text.erb" => true)
+          runner.review('app/mailers/project_mailer.rb', content)
+          runner.should have(0).errors
+
+          mock_email_files(["send_email.html.erb", "send_email.text.haml"], "html.erb" => true, "text.haml" => true)
           runner.review('app/mailers/project_mailer.rb', content)
           runner.should have(0).errors
         end


### PR DESCRIPTION
In a project I'm mixing haml and erb to generate emails. I'm using erb so I can easily use indentation in the plain text emails and haml because it's awesome for HTML.
However, the rails_best_practices complains about this in the report, suggesting I use multipart/alternative, which I already do. 

I've made a fix for this in the rails3 part of the checks and wrote specs to verify the solution.
