### PR TITLE
ruby-progressbar -> progressbar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       colored
       erubis
       i18n
-      ruby-progressbar
+      progressbar
       sexp_processor
 
 GEM
@@ -18,6 +18,7 @@ GEM
     erubis (2.7.0)
     haml (3.1.3)
     i18n (0.5.0)
+    progressbar (0.9.1)
     rake (0.8.7)
     ripper (1.0.2)
     rspec (2.4.0)
@@ -28,7 +29,6 @@ GEM
     rspec-expectations (2.4.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.4.0)
-    ruby-progressbar (0.0.10)
     sexp_processor (3.0.5)
     watchr (0.7)
 

--- a/rails_best_practices.gemspec
+++ b/rails_best_practices.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency("sexp_processor")
-  s.add_dependency("ruby-progressbar")
+  s.add_dependency("progressbar")
   s.add_dependency("colored")
   s.add_dependency("erubis")
   s.add_dependency("i18n")


### PR DESCRIPTION
The gem was renamed a while ago. Since the RBP gem depends on the older one, our project now has two progressbar gems installed which are actually the same gem, just different versions.

As far as I can tell the API has not changed. A quick test showed that the RBP gem works fine with progressbar 0.9.1.
