### PR TITLE
Plugins were not being loaded in REE/1.8.7

### DIFF
--- a/lib/rails_best_practices/core/runner.rb
+++ b/lib/rails_best_practices/core/runner.rb
@@ -169,12 +169,12 @@ module RailsBestPractices
         # load all plugin reviews.
         def load_plugin_reviews
           begin
-            plugins = "lib/rails_best_practices/plugins/reviews"
+            plugins = "#{Runner.base_path}lib/rails_best_practices/plugins/reviews"
             if File.directory?(plugins)
               Dir[File.expand_path(File.join(plugins, "*.rb"))].each do |review|
                 require review
               end
-              if RailsBestPractices.constants.include? :Plugins
+              if RailsBestPractices.constants.map(&:to_sym).include? :Plugins
                 RailsBestPractices::Plugins::Reviews.constants.each do |review|
                   @reviews << RailsBestPractices::Plugins::Reviews.const_get(review).new
                 end

--- a/spec/fixtures/lib/rails_best_practices/plugins/reviews/not_use_rails_root_review.rb
+++ b/spec/fixtures/lib/rails_best_practices/plugins/reviews/not_use_rails_root_review.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+require 'rails_best_practices/reviews/review'
+
+module RailsBestPractices
+  module Plugins
+    module Reviews
+      class NotUseRailsRootReview < RailsBestPractices::Reviews::Review
+      end
+    end
+  end
+end

--- a/spec/rails_best_practices/core/runner_spec.rb
+++ b/spec/rails_best_practices/core/runner_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe RailsBestPractices::Core::Runner do
+
+  before { RailsBestPractices::Core::Runner.base_path = 'spec/fixtures/' }
+
+  describe "load_plugin_reviews" do
+    it "should load plugins in lib/rails_best_practices/plugins/reviews" do
+      runner = RailsBestPractices::Core::Runner.new
+      runner.instance_variable_get('@reviews').map(&:class).should include(RailsBestPractices::Plugins::Reviews::NotUseRailsRootReview)
+    end
+  end
+end


### PR DESCRIPTION
RailsBestPractices.constants would return an array of strings in REE/Ruby 1.8.7 preventing plugins from ever being loaded.

I branched off 0.10.1 since we want to use rails_best_practices with a web service but the server is running on REE and currently ripper causes segfaults. 

It should apply equally well to master though! I hope the segfaults can be resolved :)
