### PR TITLE
Fixed plugins not being loaded properly.

### DIFF
--- a/lib/rails_best_practices/core/runner.rb
+++ b/lib/rails_best_practices/core/runner.rb
@@ -202,7 +202,7 @@ module RailsBestPractices
         # load all plugin reviews.
         def load_plugin_reviews
           begin
-            plugins = "#{Runner.base_path}lib/rails_best_practices/plugins/reviews"
+            plugins = File.join(Runner.base_path, 'lib', 'rails_best_practices', 'plugins', 'reviews')
             if File.directory?(plugins)
               Dir[File.expand_path(File.join(plugins, "*.rb"))].each do |review|
                 require review

--- a/spec/rails_best_practices/core/runner_spec.rb
+++ b/spec/rails_best_practices/core/runner_spec.rb
@@ -1,13 +1,22 @@
 require 'spec_helper'
 
 describe RailsBestPractices::Core::Runner do
-
-  before { RailsBestPractices::Core::Runner.base_path = 'spec/fixtures/' }
-
   describe "load_plugin_reviews" do
-    it "should load plugins in lib/rails_best_practices/plugins/reviews" do
-      runner = RailsBestPractices::Core::Runner.new
-      runner.instance_variable_get('@reviews').map(&:class).should include(RailsBestPractices::Plugins::Reviews::NotUseRailsRootReview)
+    shared_examples_for 'load_plugin_reviews' do
+      it "should load plugins in lib/rails_best_practices/plugins/reviews" do
+        runner = RailsBestPractices::Core::Runner.new
+        runner.instance_variable_get('@reviews').map(&:class).should include(RailsBestPractices::Plugins::Reviews::NotUseRailsRootReview)
+      end
+    end
+
+    context "given a path that ends with a slash" do
+      before { RailsBestPractices::Core::Runner.base_path = 'spec/fixtures/' }
+      it_should_behave_like 'load_plugin_reviews'
+    end
+
+    context "given a path that does not end with a slash" do
+      before { RailsBestPractices::Core::Runner.base_path = 'spec/fixtures' }
+      it_should_behave_like 'load_plugin_reviews'
     end
   end
 end


### PR DESCRIPTION
Path was not being set correctly when using default '.' base_path (was missing a slash), so the path would be incorrectly interpolated as '.lib/plugins/rails_best_practices/plugins/reviews'.
