### PR TITLE
Also skip HAML files with invalid syntax

### DIFF
--- a/lib/rails_best_practices/core/runner.rb
+++ b/lib/rails_best_practices/core/runner.rb
@@ -159,7 +159,7 @@ module RailsBestPractices
               content.gsub!(/\\\d{3}/, '')
             rescue LoadError
               raise "In order to parse #{filename}, please install the haml gem"
-            rescue Haml::Error
+            rescue Haml::Error, SyntaxError
               # do nothing, just ignore the wrong haml files.
             end
           end


### PR DESCRIPTION
HAML files will not only raise HAML:Error but can also raise SyntaxError if the syntax itself is messed up.
