### PR TITLE
Controllers for inherited_resources were failing to parse without an ':except' argument attached.

### DIFF
--- a/lib/rails_best_practices/prepares/controller_prepare.rb
+++ b/lib/rails_best_practices/prepares/controller_prepare.rb
@@ -51,7 +51,7 @@ module RailsBestPractices
           if "all" == node.arguments.all.first.to_s
             @actions = DEFAULT_ACTIONS
             option_argument = node.arguments.all[1]
-            if :bare_assoc_hash == option_argument.sexp_type && option_argument.hash_value("except")
+            if option_argument && :bare_assoc_hash == option_argument.sexp_type && option_argument.hash_value("except")
               @actions -= option_argument.hash_value("except").to_object
             end
           else

--- a/spec/rails_best_practices/prepares/controller_prepare_spec.rb
+++ b/spec/rails_best_practices/prepares/controller_prepare_spec.rb
@@ -100,6 +100,17 @@ describe RailsBestPractices::Prepares::ControllerPrepare do
         methods.get_methods("PostsController").map(&:method_name).should == ["index", "new", "create", "edit", "update", "destroy"]
       end
 
+      it "extend inherited_resources with all actions with no arguments" do
+        content =<<-EOF
+        class PostsController < InheritedResources::Base
+          actions :all
+        end
+        EOF
+        runner.prepare('app/controllers/posts_controller.rb', content)
+        methods = RailsBestPractices::Prepares.controller_methods
+        methods.get_methods("PostsController").map(&:method_name).should == ["index", "show", "new", "create", "edit", "update", "destroy"]
+      end
+
       it "DSL inherit_resources" do
         content =<<-EOF
         class PostsController


### PR DESCRIPTION
With a controller (no arguments on actions :all) :

```
class PostsController < InheritedResources::Base
    actions :all
end
```

Throws exceptions :
/Users/tom/.rvm/gems/ruby-1.9.2-p290-patched@newco/gems/rails_best_practices-1.5.3/lib/rails_best_practices/prepares/controller_prepare.rb:56:in `start_command': undefined method`sexp_type' for nil:NilClass (NoMethodError)

Test attached to fix this.
