### PR TITLE
Fixed typo

### DIFF
--- a/spec/rails_best_practices/prepares/helper_prepare_spec.rb
+++ b/spec/rails_best_practices/prepares/helper_prepare_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RailsBestPractices::Prepares::HelperPrepare do
-  let(:runner) { RailsBestPractices::Core::Runner.new(:parepare => RailsBestPractices::Prepares::HelperPrepare.new) }
+  let(:runner) { RailsBestPractices::Core::Runner.new(:prepares => RailsBestPractices::Prepares::HelperPrepare.new) }
 
   context "methods" do
     it "should parse helper methods" do


### PR DESCRIPTION
A spec with a typo where :prepares are passed in to RailsBestPractices::Core::Runner.new. The spec passed anyway as the initializer defaulted to loading all prepares. Fixing this amounts to an optimization, I suppose.
