### PR TITLE
removing string injection in order to prevent problems with activerecord

### DIFF
--- a/lib/rails_best_practices/core.rb
+++ b/lib/rails_best_practices/core.rb
@@ -15,7 +15,6 @@ require 'rails_best_practices/core/controllers'
 require 'rails_best_practices/core/helpers'
 require 'rails_best_practices/core/routes'
 
-require 'rails_best_practices/core_ext/string'
 require 'rails_best_practices/core_ext/sexp'
 require 'rails_best_practices/core_ext/enumerable'
 require 'rails_best_practices/core_ext/erubis'

--- a/lib/rails_best_practices/core/model_associations.rb
+++ b/lib/rails_best_practices/core/model_associations.rb
@@ -48,7 +48,7 @@ module RailsBestPractices
       # @param [String] association_name
       # @return [String] association's class name
       def get_association_class_name(table_name, association_name)
-        associations = @associations.select { |model, model_associations| model.table_name == table_name }.values.first and
+        associations = @associations.select { |model, model_associations| model.gsub("::", "").tableize == table_name }.values.first and
           association_meta = associations.select { |name, meta| name == association_name }.values.first and
           association_meta["class_name"]
       end

--- a/lib/rails_best_practices/core_ext/string.rb
+++ b/lib/rails_best_practices/core_ext/string.rb
@@ -1,5 +1,0 @@
-class String
-  def table_name
-    self.gsub("::", "").tableize
-  end
-end

--- a/lib/rails_best_practices/reviews/always_add_db_index_review.rb
+++ b/lib/rails_best_practices/reviews/always_add_db_index_review.rb
@@ -130,7 +130,7 @@ module RailsBestPractices
             foreign_keys.delete_if do |key|
               if key =~ /_id$/
                 class_name = Prepares.model_associations.get_association_class_name(table, key[0..-4])
-                class_name ? !@table_nodes[class_name.table_name] : !@table_nodes[key[0..-4].pluralize]
+                class_name ? !@table_nodes[class_name.gsub("::", "").tableize] : !@table_nodes[key[0..-4].pluralize]
               end
             end
           end

--- a/lib/rails_best_practices/reviews/restrict_auto_generated_routes_review.rb
+++ b/lib/rails_best_practices/reviews/restrict_auto_generated_routes_review.rb
@@ -86,10 +86,10 @@ module RailsBestPractices
             if hash_key_exist?(option_node,"controller")
               name = option_node.hash_value("controller").to_s
             else
-              name = node.arguments.all.first.to_s.table_name
+              name = node.arguments.all.first.to_s.gsub("::", "").tableize
             end
           else
-            name = node.arguments.all.first.to_s.table_name
+            name = node.arguments.all.first.to_s.gsub("::", "").tableize
           end
           namespaced_class_name(name)
         end


### PR DESCRIPTION
Hi,

The current version of RailsBestPractices injects a method called "table_name" into the class String.  This causes problems when other code assumes the class String will have no method that is named this.

ActiveRecord (all versions > 3.0) has code that assumes String has no method named "table_name".  See this line of code for an example:

https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/migration.rb#L585

This caused migrations to fail in my environment when including the RailsBestPractices gem.  I am including a patch that removes this injection.

Thanks!
