### PR TITLE
attr_accessible can be specified without arguments to block all 

### DIFF
--- a/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
+++ b/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
@@ -29,6 +29,7 @@ module RailsBestPractices
 
       private
         def rails_builtin?(node)
+          node.grep_node(:sexp_type => :vcall, :to_s => "attr_accessible").present? ||
           node.grep_node(:sexp_type => :command, :message => %w(attr_accessible attr_protected)).present?
         end
 

--- a/spec/rails_best_practices/reviews/protect_mass_assignment_review_spec.rb
+++ b/spec/rails_best_practices/reviews/protect_mass_assignment_review_spec.rb
@@ -13,10 +13,20 @@ describe RailsBestPractices::Reviews::ProtectMassAssignmentReview do
     runner.errors[0].to_s.should == "app/models/user.rb:1 - protect mass assignment"
   end
 
-  it "should not protect mass assignment with attr_accessible" do
+  it "should not protect mass assignment if attr_accessible is used with arguments" do
     content =<<-EOF
     class User < ActiveRecord::Base
       attr_accessible :email, :password, :password_confirmation
+    end
+    EOF
+    runner.review('app/models/user.rb', content)
+    runner.should have(0).errors
+  end
+
+  it "should not protect mass assignment if attr_accessible is used without arguments" do
+    content =<<-EOF
+    class User < ActiveRecord::Base
+      attr_accessible
     end
     EOF
     runner.review('app/models/user.rb', content)


### PR DESCRIPTION
As per this thread...

http://stackoverflow.com/questions/4838399/how-i-can-set-attr-accessible-in-order-to-not-allow-access-to-any-of-the-field

... it is possible to use `attr_accessible` without any arguments to blanket ban mass assignment for a model. However, _rails_best_practices_ seems to ignore this use case, and raises a "protect mass assignment" warning when `attr_accessible` gets called without arguments.

I'm extremely unfamiliar with the codebase, so I copied the implementation of rspec test and check for _authlogic without configuration_, and that seems to work. It would be great if you could verify my changes. 

As an alternative, I'd tried setting...

``` ruby
config.active_record.whitelist_attributes = true
```

... which seems to be the best way to block mass assignment altogether, as mentioned at rails-bestpractices.com, but the gem seems not to take that into account when checking for _mass assignment protection_, i.e, for models which completely disallow mass assignment.
