### PR TITLE
Testing for ActiveRecord::Base inherit models only

### DIFF
--- a/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
+++ b/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
@@ -25,7 +25,7 @@ module RailsBestPractices
       # and if not use devise or authlogic,
       # then it should add attr_accessible or attr_protected to protect mass assignment.
       def start_class(node)
-        if !whitelist_attributes_config? && !rails_builtin?(node) && !devise?(node) && !authlogic?(node)
+        if !whitelist_attributes_config? && !rails_builtin?(node) && !devise?(node) && !authlogic?(node) && is_active_record?(node)
           add_error "protect mass assignment"
         end
       end
@@ -47,6 +47,10 @@ module RailsBestPractices
         def authlogic?(node)
          node.grep_node(:sexp_type => [:vcall, :var_ref], :to_s => "acts_as_authentic").present? ||
          node.grep_node(:sexp_type => :fcall, :message => "acts_as_authentic").present?
+        end
+
+        def is_active_record?(node)
+          node.grep_node(:sexp_type => [:const_path_ref, :@const], :to_s => "ActiveRecord::Base").present?
         end
     end
   end

--- a/spec/rails_best_practices/reviews/protect_mass_assignment_review_spec.rb
+++ b/spec/rails_best_practices/reviews/protect_mass_assignment_review_spec.rb
@@ -93,6 +93,15 @@ module RailsBestPractices
         runner.review('app/models/user.rb', content)
         runner.should have(0).errors
       end
+
+      it "should not protect mass assignment if checking non ActiveRecord::Base inherited model" do
+          content =<<-EOF
+          class User < Person
+          end
+          EOF
+          runner.review('app/models/user.rb', content)
+          runner.should have(0).errors
+        end
     end
   end
 end


### PR DESCRIPTION
Some times our models inherit from other models, specially when using
Single Table Inheritance. Those models should not be checked, once their
superclasses probably were.
