### PR TITLE
Do not treat either ids nodes as hash syntax

### DIFF
--- a/lib/rails_best_practices/reviews/hash_syntax_review.rb
+++ b/lib/rails_best_practices/reviews/hash_syntax_review.rb
@@ -59,7 +59,7 @@ module RailsBestPractices
         end
 
         def haml_class_node?(node)
-          node.hash_size == 1 && node.hash_keys.first == "class"
+          node.hash_size == 1 && (node.hash_keys.first == "class" || node.hash_keys.first == "id")
         end
     end
   end

--- a/spec/rails_best_practices/reviews/hash_syntax_review_spec.rb
+++ b/spec/rails_best_practices/reviews/hash_syntax_review_spec.rb
@@ -65,8 +65,11 @@ module RailsBestPractices
 
       it "should ignore haml_out" do
         content =<<-EOF
-%div{ id: "file-\#{file}-a" }
-.file{ id: "file-\#{file}-b" }
+
+%div{ class: "foo1" }
+.div{ class: "foo2" }
+#div{ class: "foo3" }
+
         EOF
         runner.review('app/views/files/show.html.haml', content)
         runner.should have(0).errors


### PR DESCRIPTION
Hi,

In addition to your commit 5d1ecd3f22 for the issue #118, I added support for Haml ids.
