### PR TITLE
My YAML Parser returned Strings instead of Keys. 

### DIFF
--- a/lib/rails_best_practices/reviews/hash_syntax_review.rb
+++ b/lib/rails_best_practices/reviews/hash_syntax_review.rb
@@ -15,8 +15,8 @@ module RailsBestPractices
 
       def initialize(options = {})
         super()
-        @only_symbol = options[:only_symbol]
-        @only_string = options[:only_string]
+        @only_symbol = options["only_symbol"]
+        @only_string = options["only_string"]
       end
 
       # check hash node to see if it is ruby 1.8 style.

--- a/spec/rails_best_practices/reviews/hash_syntax_review_spec.rb
+++ b/spec/rails_best_practices/reviews/hash_syntax_review_spec.rb
@@ -38,7 +38,7 @@ module RailsBestPractices
       end
 
       it "should only check symbol syntax" do
-        runner = Core::Runner.new(reviews: HashSyntaxReview.new(only_symbol: true))
+        runner = Core::Runner.new(reviews: HashSyntaxReview.new("only_symbol" => true))
         content =<<-EOF
         class User < ActiveRecord::Base
           SYMBOL_CONST = { :foo => :bar }
@@ -51,7 +51,7 @@ module RailsBestPractices
       end
 
       it "should only check string syntax" do
-        runner = Core::Runner.new(reviews: HashSyntaxReview.new(only_string: true))
+        runner = Core::Runner.new(reviews: HashSyntaxReview.new("only_string" => true))
         content =<<-EOF
         class User < ActiveRecord::Base
           SYMBOL_CONST = { :foo => :bar }


### PR DESCRIPTION
Only with this change the Options in the yaml file are parsed right.
