### PR TITLE
Don't match Helper Specs as Helper Files

### DIFF
--- a/lib/rails_best_practices/core/check.rb
+++ b/lib/rails_best_practices/core/check.rb
@@ -12,7 +12,7 @@ module RailsBestPractices
       PARTIAL_VIEW_FILES = /(views|cells)\/.*\/_.*\.(erb|haml|slim|builder|rxml)$/
       ROUTE_FILES = /config\/routes.*\.rb/
       SCHEMA_FILE = /db\/schema\.rb/
-      HELPER_FILES = /helpers\/.*\.rb$/
+      HELPER_FILES = /helpers\/((?!_spec.rb).)*\.rb$/
       DEPLOY_FILES = /config\/deploy.*\.rb/
       CONFIG_FILES = /config\/(application|environment|environments\/.*)\.rb/
 


### PR DESCRIPTION
I had the problem with:
./spec_no_rails/lib/migration_support/helpers/sql_helper_spec.rb:6 - remove empty helpers
