### PR TITLE
Mark action_controller layout methods as used.

### DIFF
--- a/lib/rails_best_practices/reviews/remove_unused_methods_in_controllers_review.rb
+++ b/lib/rails_best_practices/reviews/remove_unused_methods_in_controllers_review.rb
@@ -60,6 +60,11 @@ module RailsBestPractices
           end
         when "around_filter"
           node.arguments.all.each { |argument| mark_used(argument) }
+        when "layout"
+          first_argument = node.arguments.all.first
+          if first_argument.sexp_type == :symbol_literal
+            mark_used(first_argument)
+          end
         when "helper_method"
           node.arguments.all.each { |argument| mark_publicize(argument.to_s) }
         when "delegate"

--- a/spec/rails_best_practices/reviews/remove_unused_methods_in_controllers_review_spec.rb
+++ b/spec/rails_best_practices/reviews/remove_unused_methods_in_controllers_review_spec.rb
@@ -80,6 +80,28 @@ module RailsBestPractices
           runner.should have(0).errors
         end
 
+        it "should not remove unused methods for layout" do
+          content =<<-EOF
+          RailsBestPracticesCom::Application.routes.draw do
+            resources :posts
+          end
+          EOF
+          runner.prepare('config/routes.rb', content)
+          content =<<-EOF
+          class PostsController < ActiveRecord::Base
+            layout :choose_layout
+            private
+              def choose_layout
+                "default"
+              end
+          end
+          EOF
+          runner.prepare('app/controllers/posts_controller.rb', content)
+          runner.review('app/controllers/posts_controller.rb', content)
+          runner.after_review
+          runner.should have(0).errors
+        end
+
         it "should not remove inherited_resources methods" do
           content =<<-EOF
           RailsBestPracticesCom::Application.routes.draw do


### PR DESCRIPTION
ActionController defines a class method [layout](http://ap.rubyonrails.org/classes/ActionController/Layout/ClassMethods.html) that can accept a method delegate as an argument. Rails best practices incorrectly reports this delegate method as being unused.

This code adds a check to see if the layout method has been given a method delegate and if so, marks that method as used.
