### PR TITLE
fix index required false-positive

### DIFF
--- a/spec/rails_best_practices/reviews/always_add_db_index_review_spec.rb
+++ b/spec/rails_best_practices/reviews/always_add_db_index_review_spec.rb
@@ -153,6 +153,24 @@ module RailsBestPractices
         runner.should have(0).errors
       end
 
+      it "should not always add db index with t.index" do
+        # e.g. schema_plus creates indices like this https://github.com/lomba/schema_plus
+        content = <<-EOF
+        ActiveRecord::Schema.define(version: 20100603080629) do
+          create_table "comments", force: true do |t|
+            t.string "content"
+            t.integer "post_id"
+            t.index ["post_id"], :name => "index_comments_on_post_id"
+          end
+          create_table "posts", force: true do |t|
+          end
+        end
+        EOF
+        runner.review('db/schema.rb', content)
+        runner.after_review
+        runner.should have(0).errors
+      end
+
       it "should not always add db index with only _type column" do
         content = <<-EOF
         ActiveRecord::Schema.define(version: 20100603080629) do


### PR DESCRIPTION
I use schema_plus (via 'client_side_validations'), and it automatically adds indices for all foreign key columns, but not in a format that rails_best_practices understands.

This patch fixes that.
