### PR TITLE
Added --with-github GITHUB_NAME to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ By default rails_best_practices will do parse codes in vendor, spec, test and fe
             --without-color              only output plain text without color
             --with-textmate              open file by textmate in html format
             --with-mvim                  open file by mvim in html format
+            --with-github GITHUB_NAME    open file on github in html format. GITHUB_NAME is like railsbp/rails-bestpractices
             --with-hg                    display hg commit and username, only support html format
             --with-git                   display git commit and username, only support html format
             --template TEMPLATE          customize erb template


### PR DESCRIPTION
When quickly scanning this project, awfully helpful option like --with-github can be missed.
