### PR TITLE
Fix ForbiddenAttributesProtection false positive

### DIFF
--- a/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
+++ b/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
@@ -20,13 +20,13 @@ module RailsBestPractices
       # we treat it as mass assignment by default.
       add_callback :start_class do |node|
         @mass_assignement = true
+        check_whitelist_attributes_config
       end
 
       # check if it is ActiveRecord::Base subclass and
       # if it sets config.active_record.whitelist_attributes to true.
       add_callback :end_class do |node|
         check_active_record(node)
-        check_whitelist_attributes_config
 
         add_error "protect mass assignment" if @mass_assignement
       end
@@ -54,12 +54,12 @@ module RailsBestPractices
       private
         def check_whitelist_attributes_config
           if "true" == Prepares.configs["config.active_record.whitelist_attributes"]
-            @mass_assignement = false
+            @whitelist_attributes = true
           end
         end
 
         def check_rails_builtin(node)
-          if [node.to_s, node.message.to_s].any? { |str| %w(attr_accessible attr_protected).include? str }
+          if @whitelist_attributes && [node.to_s, node.message.to_s].any? { |str| %w(attr_accessible attr_protected).include? str }
             @mass_assignement = false
           end
         end

--- a/spec/rails_best_practices/reviews/protect_mass_assignment_review_spec.rb
+++ b/spec/rails_best_practices/reviews/protect_mass_assignment_review_spec.rb
@@ -15,7 +15,15 @@ module RailsBestPractices
         runner.errors[0].to_s.should == "app/models/user.rb:1 - protect mass assignment"
       end
 
-      it "should not protect mass assignment if attr_accessible is used with arguments" do
+      it "should not protect mass assignment if attr_accessible is used with arguments and user set config.active_record.whitelist_attributes" do
+        content =<<-EOF
+        module RailsBestPracticesCom
+          class Application < Rails::Application
+            config.active_record.whitelist_attributes = true
+          end
+        end
+        EOF
+        runner.prepare('config/application.rb', content)
         content =<<-EOF
         class User < ActiveRecord::Base
           attr_accessible :email, :password, :password_confirmation
@@ -25,7 +33,15 @@ module RailsBestPractices
         runner.should have(0).errors
       end
 
-      it "should not protect mass assignment if attr_accessible is used without arguments" do
+      it "should not protect mass assignment if attr_accessible is used without arguments and user set config.active_record.whitelist_attributes" do
+        content =<<-EOF
+        module RailsBestPracticesCom
+          class Application < Rails::Application
+            config.active_record.whitelist_attributes = true
+          end
+        end
+        EOF
+        runner.prepare('config/application.rb', content)
         content =<<-EOF
         class User < ActiveRecord::Base
           attr_accessible
@@ -35,7 +51,15 @@ module RailsBestPractices
         runner.should have(0).errors
       end
 
-      it "should not protect mass assignment with attr_protected" do
+      it "should not protect mass assignment with attr_protected if user set config.active_record.whitelist_attributes" do
+        content =<<-EOF
+        module RailsBestPracticesCom
+          class Application < Rails::Application
+            config.active_record.whitelist_attributes = true
+          end
+        end
+        EOF
+        runner.prepare('config/application.rb', content)
         content =<<-EOF
         class User < ActiveRecord::Base
           attr_protected :role
@@ -71,23 +95,6 @@ module RailsBestPractices
         content =<<-EOF
         class User < ActiveRecord::Base
           acts_as_authentic
-        end
-        EOF
-        runner.review('app/models/user.rb', content)
-        runner.should have(0).errors
-      end
-
-      it "should not protect mass assignment if user set config.active_record.whitelist_attributes" do
-        content =<<-EOF
-        module RailsBestPracticesCom
-          class Application < Rails::Application
-            config.active_record.whitelist_attributes = true
-          end
-        end
-        EOF
-        runner.prepare('config/application.rb', content)
-        content =<<-EOF
-        class User < ActiveRecord::Base
         end
         EOF
         runner.review('app/models/user.rb', content)


### PR DESCRIPTION
This fixes #151, so one can remove whitelist_attributes, which is not necessary when using strong_parameters and gives a deprecation warning in Rails 4.
