### PR TITLE
Extend with-github flag to take full path to GitHub:FI repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By default rails_best_practices will do parse codes in vendor, spec, test and fe
             --with-textmate              open file by textmate in html format
             --with-sublime               open file by sublime in html format (requires https://github.com/asuth/subl-handler)
             --with-mvim                  open file by mvim in html format
-            --with-github GITHUB_NAME    open file on github in html format. GITHUB_NAME is like railsbp/rails-bestpractices
+            --with-github GITHUB_NAME    open file on github in html format. GITHUB_NAME is like railsbp/rails-bestpractices OR full URL to GitHub:FI repo
             --with-hg                    display hg commit and username, only support html format
             --with-git                   display git commit and username, only support html format
             --template TEMPLATE          customize erb template

--- a/assets/result.html.erb
+++ b/assets/result.html.erb
@@ -111,7 +111,7 @@
           <tr class="<%= error.type.split(':').last %>">
             <td class='filename'>
               <% if @github %>
-                <a href='https://github.com/<%= @github_name %>/blob/<%= @last_commit_id %>/<%= error.short_filename %>#L<%= error.first_line_number %>' target='_blank'><%= error.short_filename %></a>
+                <a href='<%= @github_name %>/blob/<%= @last_commit_id %>/<%= error.short_filename %>#L<%= error.first_line_number %>' target='_blank'><%= error.short_filename %></a>
               <% elsif @textmate %>
                 <a href='txmt://open/?url=file://<%= File.expand_path(error.filename) %>&amp;line=<%= error.line_number %>'><%= error.short_filename %></a>
               <% elsif @sublime %>

--- a/lib/rails_best_practices/analyzer.rb
+++ b/lib/rails_best_practices/analyzer.rb
@@ -21,6 +21,7 @@ module RailsBestPractices
     attr_reader :path
 
     DEFAULT_CONFIG = File.join(File.dirname(__FILE__), "..", "..", "rails_best_practices.yml")
+    GITHUB_URL = 'https://github.com/'
 
     # initialize
     #
@@ -221,6 +222,9 @@ module RailsBestPractices
 
       if @options["with-github"]
         last_commit_id = @options["last-commit-id"] ? @options["last-commit-id"] : `cd #{@runner.class.base_path} && git rev-parse HEAD`.chomp
+        unless @options["github-name"].start_with?('http')
+          @options["github-name"] = GITHUB_URL + @options["github-name"]
+        end
       end
       File.open(@options["output-file"], "w+") do |file|
         eruby = Erubis::Eruby.new(template)


### PR DESCRIPTION
For using rails_best_practices when you have a private github server
that you'd like to link to.
