### PR TITLE
Fix broken sublime-text links

### DIFF
--- a/assets/result.html.erb
+++ b/assets/result.html.erb
@@ -115,7 +115,7 @@
               <% elsif @textmate %>
                 <a href='txmt://open/?url=file://<%= File.expand_path(error.filename) %>&amp;line=<%= error.line_number %>'><%= error.short_filename %></a>
               <% elsif @sublime %>
-                <a href='"subl://open?url=file://"<%= File.expand_path(error.filename) %>&amp;line=<%= error.line_number %>'><%= error.short_filename %></a>
+                <a href='subl://open?url=file://<%= File.expand_path(error.filename) %>&amp;line=<%= error.line_number %>'><%= error.short_filename %></a>
               <% elsif @mvim %>
                 <a href='mvim://open/?url=file://<%= File.expand_path(error.filename) %>&amp;line=<%= error.line_number %>'><%= error.short_filename %></a>
               <% else %>


### PR DESCRIPTION
The current version doesn't work and leads to an error.
It was easy to fix and make it work on my machine.
