### PR TITLE
[#175]  Remove ActiveSupport Dependency

### DIFF
--- a/lib/rails_best_practices/core/runner.rb
+++ b/lib/rails_best_practices/core/runner.rb
@@ -1,12 +1,6 @@
 # encoding: utf-8
 require 'yaml'
-require 'active_support/core_ext/object/blank'
-begin
-  require 'active_support/core_ext/object/try'
-rescue LoadError
-  require 'active_support/core_ext/try'
-end
-require 'active_support/inflector'
+require 'rails_best_practices/core_ext/ruby'
 
 module RailsBestPractices
   module Core

--- a/lib/rails_best_practices/core_ext/object.rb
+++ b/lib/rails_best_practices/core_ext/object.rb
@@ -1,0 +1,13 @@
+class Object
+  def blank?
+    self.nil? || self.empty?
+  rescue
+    false
+  end
+  def try(method_symbol)
+    present? && public_send(method_symbol) || self
+  end
+  def present?
+    !blank?
+  end
+end

--- a/lib/rails_best_practices/core_ext/ruby.rb
+++ b/lib/rails_best_practices/core_ext/ruby.rb
@@ -1,0 +1,2 @@
+require 'rails_best_practices/core_ext/object'
+require 'rails_best_practices/core_ext/string'

--- a/lib/rails_best_practices/core_ext/string.rb
+++ b/lib/rails_best_practices/core_ext/string.rb
@@ -1,0 +1,18 @@
+require 'inflecto'
+class String
+  def tableize
+    Inflecto.tableize(self)
+  end
+  def camelize
+    Inflecto.camelize(self)
+  end
+  def classify
+    Inflecto.classify(self)
+  end
+  def pluralize
+    Inflecto.pluralize(self)
+  end
+  def underscore
+    Inflecto.underscore(self)
+  end
+end

--- a/rails_best_practices.gemspec
+++ b/rails_best_practices.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.0"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency("activesupport")
+  s.add_dependency("inflecto")
   s.add_dependency("awesome_print")
   s.add_dependency("code_analyzer", ">= 0.4.2")
   s.add_dependency("colored")


### PR DESCRIPTION
See #175

```
Whereas:
- ActiveSupport has a big footprint.
- Requiring it can affect compatibility with other libraries
- The parts of it used in rbp are minimal

Remove ActiveSupport in favor of custom monkey-patches.
Adding the Inflecto gem as a dependency as it was extracted from
the ActiveSupport Inflector and alows rbp to nicely handle
pluralizing and singularizing strings.

Rbp will fallback on its custom patches if ActiveSupport is not
available
```
