### PR TITLE
Fix false positives for "protect mass assignment"

### DIFF
--- a/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
+++ b/lib/rails_best_practices/reviews/protect_mass_assignment_review.rb
@@ -71,7 +71,7 @@ module RailsBestPractices
         end
 
         def check_rails_builtin(node)
-          if @whitelist_attributes && [node.to_s, node.message.to_s].any? { |str| %w(attr_accessible attr_protected).include? str }
+          if @whitelist_attributes || [node.to_s, node.message.to_s].any? { |str| %w(attr_accessible attr_protected).include? str }
             @mass_assignement = false
           end
         end


### PR DESCRIPTION
RBP is giving false positives for "protect mass assignment" when config.active_record.whitelist_attributes is set to false but attributes are whitelisted using attr_accessible in the models. It's also giving false positives when used to analyze mountanble engines. This is happening in all versions above 1.13.4. 

It's happening because in ProtectMassAssignmentReview the condition to check mass_assignment is:

if @whitelist_attributes && [node.to_s, node.message.to_s].any? { |str| %w(attr_accessible attr_protected).include? str }

The bug could be fixed by changing the above condition to:

 if @whitelist_attributes || [node.to_s, node.message.to_s].any? { |str| %w(attr_accessible attr_protected).include? str }
