### PR TITLE
replace depracated ".stub!" with "stub"

### DIFF
--- a/spec/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review_spec.rb
+++ b/spec/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review_spec.rb
@@ -5,24 +5,24 @@ module RailsBestPractices
     describe UseMultipartAlternativeAsContentTypeOfEmailReview do
       let(:runner) { Core::Runner.new(reviews: UseMultipartAlternativeAsContentTypeOfEmailReview.new) }
 
-      before(:each) { Core::Runner.stub!(:base_path).and_return(".") }
+      before(:each) { Core::Runner.stub(:base_path).and_return(".") }
 
       def mock_email_files(entry_files, options={})
-        Dir.stub!(:entries).with("./app/views/project_mailer").and_return(entry_files)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.plain.erb").and_return(options["text.plain.erb"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.html.erb").and_return(options["text.html.erb"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.erb").and_return(options["text.erb"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.html.erb").and_return(options["html.erb"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.plain.haml").and_return(options["text.plain.haml"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.html.haml").and_return(options["text.html.haml"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.haml").and_return(options["text.haml"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.html.haml").and_return(options["html.haml"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.plain.slim").and_return(options["text.plain.slim"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.html.slim").and_return(options["text.html.slim"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.slim").and_return(options["text.slim"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.html.slim").and_return(options["html.slim"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.plain.rhtml").and_return(options["text.plain.rhtml"] || false)
-        File.stub!(:exist?).with("./app/views/project_mailer/send_email.text.html.rhtml").and_return(options["text.html.rhtml"] || false)
+        Dir.stub(:entries).with("./app/views/project_mailer").and_return(entry_files)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.plain.erb").and_return(options["text.plain.erb"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.html.erb").and_return(options["text.html.erb"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.erb").and_return(options["text.erb"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.html.erb").and_return(options["html.erb"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.plain.haml").and_return(options["text.plain.haml"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.html.haml").and_return(options["text.html.haml"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.haml").and_return(options["text.haml"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.html.haml").and_return(options["html.haml"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.plain.slim").and_return(options["text.plain.slim"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.html.slim").and_return(options["text.html.slim"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.slim").and_return(options["text.slim"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.html.slim").and_return(options["html.slim"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.plain.rhtml").and_return(options["text.plain.rhtml"] || false)
+        File.stub(:exist?).with("./app/views/project_mailer/send_email.text.html.rhtml").and_return(options["text.html.rhtml"] || false)
       end
 
       context "rails2" do


### PR DESCRIPTION
and get rid of the 1000 annoying warnings :)

Here is one of get as example:

DEPRECATION: stub! is deprecated. Use stub instead. Called from /Users/lucaspinto/Projects/rails_best_practices/spec/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review_spec.rb:25:in `mock_email_files'.
