### PR TITLE
Let user to ommit empty hashes in configuration file

### DIFF
--- a/lib/rails_best_practices/core/runner.rb
+++ b/lib/rails_best_practices/core/runner.rb
@@ -132,6 +132,7 @@ module RailsBestPractices
             begin
               check_name, options = *check
               klass = RailsBestPractices::Lexicals.const_get(check_name)
+              options = Hash(options)
               active_checks << (options.empty? ? klass.new : klass.new(options))
             rescue
               # the check does not exist in the Lexicals namepace.
@@ -151,6 +152,7 @@ module RailsBestPractices
             begin
               check_name, options = *check
               klass = RailsBestPractices::Reviews.const_get(check_name.gsub(/Check$/, 'Review'))
+              options = Hash(options)
               active_checks << (options.empty? ? klass.new : klass.new(options))
             rescue
               # the check does not exist in the Reviews namepace.


### PR DESCRIPTION
I believe that config file looks better without all these braces, so I created tiny patch to let ommit them for checkers without options specified.
