### PR TITLE
support regex syntax in except_method checks

### DIFF
--- a/spec/rails_best_practices/core/except_methods_spec.rb
+++ b/spec/rails_best_practices/core/except_methods_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module RailsBestPractices::Core
+  describe Check::Exceptable do
+    let(:method) { Method.new "BlogPost", "approve", "public", {} }
+
+    context "wildcard class and method" do
+      let(:except_method) { '*#*' }
+
+      it "matches" do
+        expect(Check::Exceptable.matches(method, except_method)).to eql true
+      end
+    end
+
+    context "wildcard class and matching explicit method" do
+      let(:except_method) { '*#approve' }
+
+      it "matches" do
+        expect(Check::Exceptable.matches(method, except_method)).to eql true
+      end
+    end
+
+    context "wildcard class and non-matching explicit method" do
+      let(:except_method) { '*#disapprove' }
+
+      it "matches" do
+        expect(Check::Exceptable.matches(method, except_method)).to eql false
+      end
+    end
+
+    context "matching class and wildcard method" do
+      let(:except_method) { 'BlogPost#*' }
+
+      it "matches" do
+        expect(Check::Exceptable.matches(method, except_method)).to eql true
+      end
+    end
+
+    context "non-matching class and wildcard method" do
+      let(:except_method) { 'User#*' }
+
+      it "matches" do
+        expect(Check::Exceptable.matches(method, except_method)).to eql false
+      end
+    end
+
+    context "matching class and matching method" do
+      let(:except_method) { 'BlogPost#approve' }
+
+      it "matches" do
+        expect(Check::Exceptable.matches(method, except_method)).to eql true
+      end
+    end
+
+    context "non-matching class and non-matching method" do
+      let(:except_method) { 'User#disapprove' }
+
+      it "matches" do
+        expect(Check::Exceptable.matches(method, except_method)).to eql false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi. I found the except_method syntax didn't give me enough power to specify blocks of classes based on a name suffix, e.g. excluding all methods from the "unused method" check if their name ended with `Responder`. It seemed this matching logic was a natural fit for regular expressions, so I've implemented that in the Excepted module. It still supports the original `*` wildcard character, so `*#*` will match all methods on all classes. But now you can also do `.*Responder#foo_.*`.

Specs are included. What do you think?
