### PR TITLE
CLI usage tweaks

### DIFF
--- a/lib/rails_best_practices/command.rb
+++ b/lib/rails_best_practices/command.rb
@@ -4,7 +4,7 @@ require "optparse"
 # Usage: rails_best_practices [options] path
 #    -d, --debug                      debug mode
 #        --silent                     silent mode
-#    -f, --format FORMAT              output format
+#    -f, --format FORMAT              output format (text, html, yml)
 #        --output-file FILE           output html file for the analyzing result
 #        --without-color              only output plain text without color
 #        --with-textmate              open file by textmate in html format
@@ -25,7 +25,9 @@ require "optparse"
 #    -g, --generate                   generate configuration yaml
 #    -v, --version                    show this version
 #    -h, --help                       show this message
+
 options = {}
+
 OptionParser.new do |opts|
   opts.banner = "Usage: rails_best_practices [options] path"
 
@@ -33,7 +35,7 @@ OptionParser.new do |opts|
     options["debug"] = true
   end
 
-  opts.on("-f", "--format FORMAT", "output format") do |format|
+  opts.on("-f", "--format FORMAT", "output format (text, html, yml)") do |format|
     options["format"] = format
   end
 


### PR DESCRIPTION
This PR makes a few changes to the CLI command:
- Single-quote / double-quote usage fix
- Specifies available formats when calling `rails_best_practices --help`. It was not clear what formats are available and it does not raise any error if provided format is not available
