### PR TITLE
Bundler gem tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 require "bundler"
+require "bundler/gem_tasks"
+
 Bundler.setup
 
 require "rake"
@@ -7,23 +9,6 @@ require "rspec/core/rake_task"
 
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rails_best_practices/version"
-
-task :build do
-  system "gem build rails_best_practices.gemspec"
-end
-
-task :install => :build do
-  system "sudo gem install rails_best_practices-#{RailsBestPractices::VERSION}.gem"
-end
-
-task :release => :build do
-  puts "Tagging #{RailsBestPractices::VERSION}..."
-  system "git tag -a #{RailsBestPractices::VERSION} -m 'Tagging #{RailsBestPractices::VERSION}'"
-  puts "Pushing to Github..."
-  system "git push --tags"
-  puts "Pushing to rubygems.org..."
-  system "gem push rails_best_practices-#{RailsBestPractices::VERSION}.gem"
-end
 
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/**/*_spec.rb"


### PR DESCRIPTION
Instead of rolling own build & release rake tasks its better to use bundler's built-in tasks. 

Example `rake -T`:

```
rake build    # Build rails_best_practices-1.15.3.gem into the pkg directory
rake install  # Build and install rails_best_practices-1.15.3.gem into system gems
rake release  # Create tag v1.15.3 and build and push rails_best_practices-1.15.3.gem to Rubygems
```
