### PR TITLE
There is no such method as remove_line_number_and_column in code_analyzer gem

### DIFF
--- a/lib/rails_best_practices/reviews/use_before_filter_review.rb
+++ b/lib/rails_best_practices/reviews/use_before_filter_review.rb
@@ -49,7 +49,7 @@ module RailsBestPractices
         def remember_first_sentence(node)
           first_sentence = node.body.statements.first
           return unless first_sentence
-          first_sentence = first_sentence.remove_line_number_and_column
+          first_sentence = first_sentence.remove_line_and_column
           unless first_sentence == s(:nil)
             @first_sentences[first_sentence] ||= []
             @first_sentences[first_sentence] << node


### PR DESCRIPTION
`remove_line_and_column` is the correct method name.
`remove_line_number_and_column` always returns `nil`
See: https://github.com/flyerhzm/code_analyzer/blob/master/lib/code_analyzer/sexp.rb#L862
