### PR TITLE
Fix RemoveUnusedMethodsInControllers warning at inline routes

### DIFF
--- a/lib/rails_best_practices/prepares/route_prepare.rb
+++ b/lib/rails_best_practices/prepares/route_prepare.rb
@@ -37,6 +37,10 @@ module RailsBestPractices
               else
                 action_names = [second_argument.hash_value("to").to_s]
               end
+            elsif :symbol_literal == first_argument.sexp_type && second_argument.try(:sexp_type) && \
+              :symbol_literal == second_argument.sexp_type
+              action_names = node.arguments.all.select \
+                {|arg| :symbol_literal == arg.sexp_type }.map(&:to_s)
             else
               action_names = [first_argument.to_s]
             end

--- a/spec/rails_best_practices/prepares/route_prepare_spec.rb
+++ b/spec/rails_best_practices/prepares/route_prepare_spec.rb
@@ -109,6 +109,26 @@ module RailsBestPractices
             "Admin::PostsController#extra_update"])
         end
 
+        it "should add resources routes with members inline" do
+          content =<<-EOF
+          RailsBestPracticesCom::Application.routes.draw do
+            namespace :admin do
+              resources :posts, :only => [:edit, :update] do
+                post :link_to_post, :extra_update, :retrieve, on: :member
+              end
+            end
+          end
+          EOF
+          runner.prepare('config/routes.rb', content)
+          routes = Prepares.routes
+          expect(routes.map(&:to_s)).to eq([
+            "Admin::PostsController#edit",
+            "Admin::PostsController#update",
+            "Admin::PostsController#link_to_post",
+            "Admin::PostsController#extra_update",
+            "Admin::PostsController#retrieve"])
+        end
+
         it "should add connect route" do
           content =<<-EOF
           ActionController::Routing::Routes.draw do |map|

--- a/spec/rails_best_practices/reviews/remove_unused_methods_in_controllers_review_spec.rb
+++ b/spec/rails_best_practices/reviews/remove_unused_methods_in_controllers_review_spec.rb
@@ -153,6 +153,27 @@ module RailsBestPractices
           expect(runner.errors[0].to_s).to eq("app/controllers/posts_controller.rb:3 - remove unused methods (PostsController#list)")
         end
 
+        it "should not remove inline routes" do
+          content =<<-EOF
+          RailsBestPracticesCom::Application.routes.draw do
+            resources :posts, only: :none do
+              get :display, :list, on: :member
+            end
+          end
+          EOF
+          runner.prepare('config/routes.rb', content)
+          content =<<-EOF
+          class PostsController < ApplicationController
+            def display; end
+            def list; end
+          end
+          EOF
+          runner.prepare('app/controllers/posts_controller.rb', content)
+          runner.review('app/controllers/posts_controller.rb', content)
+          runner.after_review
+          expect(runner.errors.size).to eq(0)
+        end
+
         it "should not remove unused methods if all actions are used in route" do
           content =<<-EOF
           ActionController::Routing::Routes.draw do |map|


### PR DESCRIPTION
Rails accept both styles to describe routes

`resources :posts do`
`  member do`
`  get :display`
`  get :list`
`  end`
`end`

and

`resources :posts do`
`  get :display, :list, on: :member`
`end`

The last example was only getting the first method. All other methods was triggering the warning 'RemoveUnusedMethodsInControllers'.

https://github.com/rails/rails/blob/7aee155f2ccba83de8d29ceb3b48901adc545a1e/actionpack/lib/action_dispatch/routing/mapper.rb#L1846