### PR TITLE
Add table_name and module_prefix to model ignored methods

### DIFF
--- a/lib/rails_best_practices/reviews/remove_unused_methods_in_models_review.rb
+++ b/lib/rails_best_practices/reviews/remove_unused_methods_in_models_review.rb
@@ -100,6 +100,7 @@ module RailsBestPractices
             before_save before_create before_update before_destroy after_save after_create
             after_update after_destroy after_find after_initialize
             method_missing
+            table_name module_prefix
           ).map { |method_name| "*\##{method_name}" }
         end
     end


### PR DESCRIPTION
At present, RBP will flag the model methods `table_name` or `module_prefix` as unused, despite these mehtods being used to confgure ActiveRecord.

This PR simply adds these two methods into the exceptions list for unusued methods in models.

This list appears to be purely config and each individual member isn't tested, so I've tested this against a project and have seen the RBP errors get silenced. I'm happy to add a test for these cases if required for merging though. Similarly, let me know if I can clarify anything.