### PR TITLE
forcing require_all version

### DIFF
--- a/lib/rails_best_practices/version.rb
+++ b/lib/rails_best_practices/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module RailsBestPractices
-  VERSION = '1.19.0'
+  VERSION = '1.19.1'
 end

--- a/rails_best_practices.gemspec
+++ b/rails_best_practices.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('code_analyzer', '>= 0.4.8')
   s.add_dependency('erubis')
   s.add_dependency('i18n')
-  s.add_dependency('require_all')
+  s.add_dependency('require_all', '~> 1.5.0')
   s.add_dependency('ruby-progressbar')
   s.add_dependency('json')
 


### PR DESCRIPTION
fixing a bug with require_all version 2.0 released today (march, 7th)


```
$ rails_best_practices                                                                                                                                                 1 ↵
Traceback (most recent call last):
        17: from /home/abacha/.rvm/gems/ruby-2.5.0/bin/ruby_executable_hooks:15:in `<main>'
        16: from /home/abacha/.rvm/gems/ruby-2.5.0/bin/ruby_executable_hooks:15:in `eval'
        15: from /home/abacha/.rvm/gems/ruby-2.5.0/bin/rails_best_practices:23:in `<main>'
        14: from /home/abacha/.rvm/gems/ruby-2.5.0/bin/rails_best_practices:23:in `load'
        13: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/rails_best_practices-1.19.0/bin/rails_best_practices:5:in `<top (required)>'
        12: from /home/abacha/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        11: from /home/abacha/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        10: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/rails_best_practices-1.19.0/lib/rails_best_practices.rb:4:in `<top (required)>'
         9: from /home/abacha/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
         8: from /home/abacha/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
         7: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/rails_best_practices-1.19.0/lib/rails_best_practices/core.rb:2:in `<top (required)>'
         6: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/require_all-2.0.0/lib/require_all.rb:117:in `require_rel'
         5: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/require_all-2.0.0/lib/require_all.rb:117:in `each'
         4: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/require_all-2.0.0/lib/require_all.rb:118:in `block in require_rel'
         3: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/require_all-2.0.0/lib/require_all.rb:96:in `require_all'
         2: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/require_all-2.0.0/lib/require_all.rb:96:in `each'
         1: from /home/abacha/.rvm/gems/ruby-2.5.0/gems/require_all-2.0.0/lib/require_all.rb:97:in `block in require_all'
/home/abacha/.rvm/gems/ruby-2.5.0/gems/require_all-2.0.0/lib/require_all.rb:102:in `rescue in block in require_all': Could not require /home/abacha/.rvm/gems/ruby-2.5.0/gems/rails_best_practices-1.19.0/lib/rails_best_practices/core/controllers.rb (uninitialized constant RailsBestPractices::Core::Klasses). Please require the necessary files (RequireAll::LoadError)
```