### PR TITLE
Update to require_all 2.x

### DIFF
--- a/lib/rails_best_practices/core/controllers.rb
+++ b/lib/rails_best_practices/core/controllers.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require_rel 'klasses'
+
 module RailsBestPractices
   module Core
     # Controller classes.

--- a/lib/rails_best_practices/core/helpers.rb
+++ b/lib/rails_best_practices/core/helpers.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require_rel 'modules'
+
 module RailsBestPractices
   module Core
     # Helper moduels.

--- a/lib/rails_best_practices/reviews/add_model_virtual_attribute_review.rb
+++ b/lib/rails_best_practices/reviews/add_model_virtual_attribute_review.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require_rel 'review'
+
 module RailsBestPractices
   module Reviews
     # Make sure to add a model virual attribute to simplify model creation.

--- a/rails_best_practices.gemspec
+++ b/rails_best_practices.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('code_analyzer', '>= 0.4.8')
   s.add_dependency('erubis')
   s.add_dependency('i18n')
-  s.add_dependency('require_all', '~> 1.5.0')
+  s.add_dependency('require_all', '~> 2.0')
   s.add_dependency('ruby-progressbar')
   s.add_dependency('json')
 


### PR DESCRIPTION
This change upgrades `require_all` to version 2.x

It has [been determined](https://github.com/jarmo/require_all/pull/24) that `require_all`'s original system of using `NameError` errors to give a load sequence is unsafe. Version 2.x fixes that. 

To accommodate it, some necessary `require_rel` lines have been added.