### PR TITLE
Update require_all dependency from 2.0 to 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       erubis
       i18n
       json
-      require_all (~> 2.0)
+      require_all (~> 3.0)
       ruby-progressbar
 
 GEM
@@ -49,7 +49,7 @@ GEM
       rspec (>= 2.14, < 4.0)
     haml (4.0.7)
       tilt
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
     listen (3.0.6)
@@ -57,7 +57,7 @@ GEM
       rb-inotify (>= 0.9.7)
     lumberjack (1.0.10)
     method_source (0.8.2)
-    minitest (5.11.3)
+    minitest (5.13.0)
     nenv (0.3.0)
     notiffany (0.0.8)
       nenv (~> 0.1)
@@ -70,7 +70,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    require_all (2.0.0)
+    require_all (3.0.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -79,8 +79,8 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
-    ruby-progressbar (1.10.0)
-    sexp_processor (4.10.1)
+    ruby-progressbar (1.10.1)
+    sexp_processor (4.13.0)
     shellany (0.0.1)
     simplecov (0.11.2)
       docile (~> 1.1.0)
@@ -100,7 +100,7 @@ GEM
     tins (1.6.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    zeitwerk (2.1.10)
+    zeitwerk (2.2.1)
 
 PLATFORMS
   ruby

--- a/rails_best_practices.gemspec
+++ b/rails_best_practices.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('erubis')
   s.add_dependency('i18n')
   s.add_dependency('json')
-  s.add_dependency('require_all', '~> 2.0')
+  s.add_dependency('require_all', '~> 3.0')
   s.add_dependency('ruby-progressbar')
 
   s.add_development_dependency('awesome_print')


### PR DESCRIPTION
Thats the only change between 2.0 and 3.0:
https://github.com/jarmo/require_all/pull/29