### PR TITLE
Splat array correctly

### DIFF
--- a/lib/rails_best_practices/reviews/remove_unused_methods_in_helpers_review.rb
+++ b/lib/rails_best_practices/reviews/remove_unused_methods_in_helpers_review.rb
@@ -20,7 +20,7 @@ module RailsBestPractices
       def initialize(options = {})
         super
         @helper_methods = Prepares.helper_methods
-        self.class.interesting_files Prepares.helpers.map(&:descendants)
+        self.class.interesting_files *Prepares.helpers.map(&:descendants)
       end
 
       # get all unused methods at the end of review process


### PR DESCRIPTION
We should pass splatted `file_patterns` to `interesting_files` so that no deprecated warnings be printed.

Starting ruby 2.7.0,  we're going to be warned when we use `Object#=~` on Array.
example)
```
$ ./bin/rails_best_practices .
/Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/core/check.rb:44: warning: deprecated Object#=~ is called on Array; it always returns nil
/Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/core/check.rb:44: warning: deprecated Object#=~ is called on Array; it always returns nil
/Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/core/check.rb:44: warning: deprecated Object#=~ is called on Array; it always returns nil
/Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/core/check.rb:44: warning: deprecated Object#=~ is called on Array; it always returns nil
/Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/core/check.rb:44: warning: deprecated Object#=~ is called on Array; it always returns nil
/Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/core/check.rb:44: warning: deprecated Object#=~ is called on Array; it always returns nil
Source Code: |========================================================================================|

Please go to https://rails-bestpractices.com to see more useful Rails Best Practices.

No warning found. Cool!
```


The problem is that empty array is added to `interesting_files`.

#### before fix(you can see  empty array at the end of the log)
```ruby
 ➜ ./bin/rails_best_practices .

[19, 28] in /Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/reviews/remove_unused_methods_in_helpers_review.rb
   19:
   20:       def initialize(options = {})
   21:         super
   22:         @helper_methods = Prepares.helper_methods
   23:         byebug
=> 24:         self.class.interesting_files Prepares.helpers.map(&:descendants)
   25:       end
   26:
   27:       # get all unused methods at the end of review process
   28:       add_callback :after_check do
(byebug) self.class.interesting_files Prepares.helpers.map(&:descendants)
[/app\/helpers\/.*\.rb$/, /app\/(views|cells)\/.*\.(erb|haml|slim|builder|rxml)$/, /app\/(controllers|cells)\/.*\.rb$/, []]
```

#### after fix
```ruby
 ➜ ./bin/rails_best_practices .

[19, 28] in /Users/harada.daisuke/.ghq/src/github.com/flyerhzm/rails_best_practices/lib/rails_best_practices/reviews/remove_unused_methods_in_helpers_review.rb
   19:
   20:       def initialize(options = {})
   21:         super
   22:         @helper_methods = Prepares.helper_methods
   23:         byebug
=> 24:         self.class.interesting_files *Prepares.helpers.map(&:descendants)
   25:       end
   26:
   27:       # get all unused methods at the end of review process
   28:       add_callback :after_check do
(byebug) self.class.interesting_files *Prepares.helpers.map(&:descendants)
[/app\/helpers\/.*\.rb$/, /app\/(views|cells)\/.*\.(erb|haml|slim|builder|rxml)$/, /app\/(controllers|cells)\/.*\.rb$/]
```

As we apply `=~` operator onto a element of `interesting_files`, the warning  appreas.
https://github.com/flyerhzm/rails_best_practices/blob/master/lib/rails_best_practices/core/check.rb#L44