### PR TITLE
Fix typo in help text

### DIFF
--- a/lib/rails_best_practices/option_parser.rb
+++ b/lib/rails_best_practices/option_parser.rb
@@ -7,7 +7,7 @@ module RailsBestPractices
     # Usage: rails_best_practices [options] path
     #    -d, --debug                      debug mode
     #        --silent                     silent mode
-    #    -f, --format FORMAT              output format (text, html, yml, json, xml)
+    #    -f, --format FORMAT              output format (text, html, yaml, json, xml)
     #        --output-file FILE           output html file for the analyzing result
     #        --without-color              only output plain text without color
     #        --with-textmate              open file by textmate in html format
@@ -41,7 +41,7 @@ module RailsBestPractices
           options['debug'] = true
         end
 
-        opts.on('-f', '--format FORMAT', 'output format (text, html, yml, json, xml)') do |format|
+        opts.on('-f', '--format FORMAT', 'output format (text, html, yaml, json, xml)') do |format|
           options['format'] = format
         end
 


### PR DESCRIPTION
Hi, I found a typo in the help text:

```diff
-yml
+yaml
```

When you run the command `rails_best_practices -f yml`, the given flag `-f yml` is ignored. I think this is not useful.
The correct command is `rails_best_practices -f yaml`.

https://github.com/flyerhzm/rails_best_practices/blob/92fefc118f1851cec952b9c9eee9e1bd56948cf8/lib/rails_best_practices/analyzer.rb#L64-L73