### PR TITLE
feat: disable warnings by inline comment

### DIFF
--- a/lib/rails_best_practices.rb
+++ b/lib/rails_best_practices.rb
@@ -8,6 +8,7 @@ require 'rails_best_practices/analyzer'
 require 'rails_best_practices/lexicals'
 require 'rails_best_practices/prepares'
 require 'rails_best_practices/reviews'
+require 'rails_best_practices/inline_disables'
 require 'rails_best_practices/option_parser'
 require 'rails_best_practices/cli'
 

--- a/lib/rails_best_practices/analyzer.rb
+++ b/lib/rails_best_practices/analyzer.rb
@@ -326,8 +326,8 @@ module RailsBestPractices
 
     # analyze source codes.
     def analyze_source_codes
-      @bar = ProgressBar.create(title: 'Source Code', total: parse_files.size * 3) if display_bar?
-      %w[lexical prepare review].each { |process| send(:process, process) }
+      @bar = ProgressBar.create(title: 'Source Code', total: parse_files.size * 4) if display_bar?
+      %w[lexical prepare review inline_disable].each { |process| send(:process, process) }
       @bar.finish if display_bar?
     end
 

--- a/lib/rails_best_practices/inline_disables.rb
+++ b/lib/rails_best_practices/inline_disables.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_rel 'inline_disables'

--- a/lib/rails_best_practices/inline_disables/comment_ripper.rb
+++ b/lib/rails_best_practices/inline_disables/comment_ripper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RailsBestPractices
+  module InlineDisables
+    class CommentRipper < Ripper::SexpBuilder
+      attr_reader :comments
+
+      def initialize(*arg)
+        super
+        @comments = []
+      end
+
+      def on_comment(*arg)
+        # [sexp_type, statement, [lineno, column]] = super
+        comments << super
+      end
+    end
+  end
+end

--- a/lib/rails_best_practices/inline_disables/inline_disable.rb
+++ b/lib/rails_best_practices/inline_disables/inline_disable.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RailsBestPractices
+  module InlineDisables
+    class InlineDisable < Core::Check
+      interesting_files ALL_FILES
+      url '#'
+
+      def initialize(*args)
+        super
+        @disabled_errors = []
+      end
+
+      def check(filename, content)
+        comments = CommentRipper.new(content).tap(&:parse).comments
+        comments.each do |_sexp_type, statement, (line_number, _column)|
+          add_as_disable_errors(filename, statement, line_number)
+        end
+      end
+
+      def disabled?(error)
+        error_key = [error.filename, error.line_number, error.type.split('::').last].join('-')
+        disabled_error_keys.include?(error_key)
+      end
+
+      private
+
+      def disabled_error_keys
+        @disabled_error_keys ||= Set.new(@disabled_errors.map { |e| [e.filename, e.line_number, e.type].join('-') })
+      end
+
+      def add_as_disable_errors(filename, statement, line_number)
+        match = statement.match(/rails_b(?:est_)?p(?:ractices)?:disable (.*)/)
+        return unless match
+
+        check_names = match[1].split(',')
+        check_names.each do |check_name|
+          add_as_disable_error(filename, check_name.gsub(/Check$/, 'Review'), line_number)
+        end
+      end
+
+      def add_as_disable_error(filename, check_name, line_number)
+        @disabled_errors <<
+          RailsBestPractices::Core::Error.new(
+            filename: filename, line_number: line_number, message: 'disable by inline comment', type: check_name, url: url
+          )
+      end
+    end
+  end
+end

--- a/spec/rails_best_practices/inline_disables/inline_disable_spec.rb
+++ b/spec/rails_best_practices/inline_disables/inline_disable_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module RailsBestPractices
+  module InlineDisables
+    describe InlineDisable do
+      let(:runner) { Core::Runner.new(reviews: Reviews::MoveModelLogicIntoModelReview.new) }
+
+      it 'moves model logic into model' do
+        content = <<-EOF
+        class PostsController < ApplicationController
+          def publish
+            @post = Post.find(params[:id])
+            @post.update_attributes(:is_published, true)
+            @post.approved_by = current_user
+
+            if @post.created_at > Time.now - 7.days
+              @post.popular = 100
+            else
+              @post.popular = 0
+            end
+
+            redirect_to post_url(@post)
+          end
+        end
+        EOF
+        runner.review('app/controllers/posts_controller.rb', content)
+        runner.inline_disable('app/controllers/posts_controller.rb', content)
+
+        expect(runner.errors.size).to eq(1)
+        expect(runner.errors[0].to_s).to eq(
+          'app/controllers/posts_controller.rb:2 - move model logic into model (@post use_count > 4)'
+        )
+      end
+
+      it 'is no error is output' do
+        content = <<-EOF
+        class PostsController < ApplicationController
+          def publish # rails_best_practices:disable MoveModelLogicIntoModelCheck
+            @post = Post.find(params[:id])
+            @post.update_attributes(:is_published, true)
+            @post.approved_by = current_user
+
+            if @post.created_at > Time.now - 7.days
+              @post.popular = 100
+            else
+              @post.popular = 0
+            end
+
+            redirect_to post_url(@post)
+          end
+        end
+        EOF
+        runner.review('app/controllers/posts_controller.rb', content)
+        runner.inline_disable('app/controllers/posts_controller.rb', content)
+
+        expect(runner.errors.size).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I would suggest stopping the warnings with inline comments.
It was also voted on in the Issue #271.

```diff
+ def index # rails_best_practices:disable MoveModelLogicIntoModelReview
- def index
  @users = User.all
  @users = @users.enabled if params[:enabled].
  @users = @users.junior if params[:junior].
  ...
end
````

I get the MoveModelLogicIntoModelCheck warning in Controller.
However, I believe there is some code that does not need to be moved to Model.
I would like to stop the warning for this method only.
I want to use `rails_best_practices:disable` or `rails_bp:disable` to stop the warnings.