### PR TITLE
Suppress deprecation warnings and errors on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'coveralls', require: false
+gem 'coveralls_reborn', require: false
 
 gem 'guard'
 gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,14 +23,13 @@ GEM
       sexp_processor
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
+    coveralls_reborn (0.24.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     diff-lcs (1.4.4)
-    docile (1.3.2)
+    docile (1.4.0)
     erubis (2.7.0)
     ffi (1.15.4)
     formatador (0.3.0)
@@ -53,7 +52,7 @@ GEM
       tilt
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
-    json (2.3.0)
+    json (2.6.2)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -88,20 +87,23 @@ GEM
     ruby-progressbar (1.11.0)
     sexp_processor (4.16.0)
     shellany (0.0.1)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
+    sync (0.5.0)
     temple (0.8.2)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (1.1.0)
+    thor (1.2.1)
     tilt (2.0.10)
-    tins (1.22.2)
+    tins (1.31.1)
+      sync
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
 
@@ -111,7 +113,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   bundler
-  coveralls
+  coveralls_reborn
   guard
   guard-rspec
   haml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,4 +124,4 @@ DEPENDENCIES
   slim
 
 BUNDLED WITH
-   2.2.22
+   2.3.15

--- a/Gemfile.ruby-2.6
+++ b/Gemfile.ruby-2.6
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'activesupport', '~> 6.1.4'
-gem 'coveralls', require: false
+gem 'coveralls_reborn', require: false
 
 gem 'guard'
 gem 'guard-rspec'

--- a/Gemfile.ruby-2.6.lock
+++ b/Gemfile.ruby-2.6.lock
@@ -24,12 +24,11 @@ GEM
       sexp_processor
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
+    coveralls_reborn (0.24.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubis (2.7.0)
@@ -89,11 +88,12 @@ GEM
     ruby-progressbar (1.11.0)
     sexp_processor (4.16.0)
     shellany (0.0.1)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -103,7 +103,7 @@ GEM
       tins (~> 1.0)
     thor (1.2.1)
     tilt (2.0.10)
-    tins (1.31.0)
+    tins (1.31.1)
       sync
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -116,7 +116,7 @@ DEPENDENCIES
   activesupport (~> 6.1.4)
   awesome_print
   bundler
-  coveralls
+  coveralls_reborn
   guard
   guard-rspec
   haml

--- a/spec/rails_best_practices/analyzer_spec.rb
+++ b/spec/rails_best_practices/analyzer_spec.rb
@@ -77,10 +77,10 @@ module RailsBestPractices
       subject { described_class.new('.', 'format' => format) }
 
       before do
-        subject.stub(:output_terminal_errors)
-        subject.stub(:output_html_errors)
-        subject.stub(:output_yaml_errors)
-        subject.stub(:output_xml_errors)
+        allow(subject).to receive(:output_terminal_errors)
+        allow(subject).to receive(:output_html_errors)
+        allow(subject).to receive(:output_yaml_errors)
+        allow(subject).to receive(:output_xml_errors)
 
         subject.output
       end


### PR DESCRIPTION
This PR suppresses some deprecation warnings and errors on CI.
Here are the details:
- Suppress deprecation warnings from rspec-mocks' `stub`
  ```
  Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /home/runner/work/rails_best_practices/rails_best_practices/spec/rails_best_practices/analyzer_spec.rb:80:in `block (3 levels) in <module:RailsBestPractices>'.
  ```
- Replace coveralls with coveralls_reborn
  - This suppresses the following error:
    ```
	[Coveralls] Submitting to https://coveralls.io/api/v1
	Coveralls encountered an exception:
	OpenSSL::SSL::SSLError
	SSL_connect returned=1 errno=0 state=error: no protocols available
	/opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/2.6.0/net/protocol.rb:44:in `connect_nonblock'
	/opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/2.6.0/net/protocol.rb:44:in `ssl_socket_connect'
	/opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/2.6.0/net/http.rb:996:in `connect'
	/opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/2.6.0/net/http.rb:930:in `do_start'
	/opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/2.6.0/net/http.rb:919:in `start'
	/opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/2.6.0/net/http.rb:1470:in `request'
	/home/runner/work/rails_best_practices/rails_best_practices/vendor/bundle/ruby/2.6.0/gems/coveralls-0.8.23/lib/coveralls/api.rb:29:in `post_json'
	/home/runner/work/rails_best_practices/rails_best_practices/vendor/bundle/ruby/2.6.0/gems/coveralls-0.8.23/lib/coveralls/simplecov.rb:64:in `format'
	/home/runner/work/rails_best_practices/rails_best_practices/vendor/bundle/ruby/2.6.0/gems/simplecov-0.16.1/lib/simplecov/result.rb:48:in `format!'
	/home/runner/work/rails_best_practices/rails_best_practices/vendor/bundle/ruby/2.6.0/gems/simplecov-0.16.1/lib/simplecov/configuration.rb:182:in `block in at_exit'
	/home/runner/work/rails_best_practices/rails_best_practices/vendor/bundle/ruby/2.6.0/gems/simplecov-0.16.1/lib/simplecov.rb:200:in `run_exit_tasks!'
	/home/runner/work/rails_best_practices/rails_best_practices/vendor/bundle/ruby/2.6.0/gems/simplecov-0.16.1/lib/simplecov/defaults.rb:27:in `block in <top (required)>'
    ```
  - Please see lemurheavy/coveralls-ruby#163 for more details.
- Update bundler from 2.2.22 to 2.3.15
  - This suppresses the following deprecation warning with Ruby 3.1:
    ```
    Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
    ```