### PR TITLE
Assign the last class as current class  when exit from a nested class

### DIFF
--- a/lib/rails_best_practices/core/check.rb
+++ b/lib/rails_best_practices/core/check.rb
@@ -138,7 +138,7 @@ module RailsBestPractices
             # end of the class
             add_callback :end_class do |_node|
               klasses.pop
-              @klass = nil
+              @klass = klasses.last
             end
           end
         end


### PR DESCRIPTION
## Motivation
I want to fix the current class as existing when exit from some current class.

For this nested situation, current class is set to nil. But, that can exists: wrapping class.


## Background

My team encountered the situation like a below example.

In the `UsersController` class, 

when we set `UnexpectedError` class definition above the **create** action, we warned about `RestrictAutoGeneratedRoutesCheck` . I think the create action was not recognized.

But 
when we set  `UnexpectedError` class definition **below** the create action, we were not warned.

```.rb
Rails.application.routes.draw do
  resources 'users', :only=> [:create]
end

class UsersController < ApplicationController
  class UnexpectedError < StandardError; end # restrict auto-generated routes users (only: [])
  def create; end
end

class UsersController < ApplicationController
  def create; end
  class UnexpectedError < StandardError; end # no warning
end
```