### PR TITLE
Fix Haml 6+ template compilation in Runner (Temple Engine#call)

### DIFF
--- a/lib/rails_best_practices/core/runner.rb
+++ b/lib/rails_best_practices/core/runner.rb
@@ -144,7 +144,7 @@ module RailsBestPractices
         elsif filename =~ /.*\.haml$/
           begin
             require 'haml'
-            content = Haml::Engine.new(content).precompiled
+            content = haml_template_to_ruby(content)
             # remove \xxx characters
             content.gsub!(/\\\d{3}/, '')
           rescue LoadError
@@ -163,6 +163,18 @@ module RailsBestPractices
           end
         end
         content
+      end
+
+      # @param [String] template Haml source
+      # @return [String] Ruby source equivalent (Haml-internal representation)
+      def haml_template_to_ruby(template)
+        # Haml 6+ is a Temple engine: `Engine#initialize` takes options, template is passed to `#call`.
+        # Haml 5 and earlier: `Engine.new(template).precompiled`.
+        if defined?(Haml::VERSION) && ::Gem::Version.new(Haml::VERSION) >= ::Gem::Version.new('6.0')
+          Haml::Engine.new.call(template)
+        else
+          Haml::Engine.new(template).precompiled
+        end
       end
 
       # load all prepares.

--- a/spec/rails_best_practices/core/runner_spec.rb
+++ b/spec/rails_best_practices/core/runner_spec.rb
@@ -4,6 +4,36 @@ require 'spec_helper'
 
 module RailsBestPractices::Core
   describe Runner do
+    describe '#parse_html_template (haml)' do
+      # Load before `it ... if:` metadata is evaluated (nested under Core, so use top-level constants).
+      require 'haml'
+
+      let(:runner) { described_class.new }
+      let(:haml_path) { 'app/views/posts/show.html.haml' }
+      let(:haml_source) { "%p.title Hello\n= link_to 'x', posts_path" }
+
+      context 'when Haml::VERSION is forced in the app environment' do
+        let(:template) { "%p\n" }
+
+        it 'uses Engine.new(template).precompiled and routes through parse_html_template' do
+          stub_const('Haml::VERSION', '5.2.0')
+          engine = instance_double(::Haml::Engine, precompiled: +"compiled\n")
+          expect(::Haml::Engine).to receive(:new).with(template).and_return(engine)
+          expect(runner.send(:parse_html_template, 'app/x.haml', template)).to eq("compiled\n")
+        end
+
+        it 'uses Engine.new with no template arg, then #call(template) — old Haml-5-only code would fail here' do
+          stub_const('Haml::VERSION', '6.0.0')
+          engine = double('haml6_engine')
+          expect(::Haml::Engine).to receive(:new).with(no_args).and_return(engine)
+          expect(engine).to receive(:call).with(template).and_return(+"from_call\n")
+          # If implementation wrongly does `Engine.new(template).precompiled`, `new` is invoked with
+          # `[template]` and this example fails immediately.
+          expect(runner.send(:parse_html_template, 'app/x.haml', template)).to eq("from_call\n")
+        end
+      end
+    end
+
     describe 'load_plugin_reviews' do
       shared_examples_for 'load_plugin_reviews' do
         it 'loads plugins in lib/rails_best_practices/plugins/reviews' do

--- a/spec/rails_best_practices/core/runner_spec.rb
+++ b/spec/rails_best_practices/core/runner_spec.rb
@@ -5,12 +5,11 @@ require 'spec_helper'
 module RailsBestPractices::Core
   describe Runner do
     describe '#parse_html_template (haml)' do
-      # Load before `it ... if:` metadata is evaluated (nested under Core, so use top-level constants).
+      # Load Haml here so the top-level `Haml` constants used by these examples are defined
+      # when the example group is set up and can be safely referenced/stubbed.
       require 'haml'
 
       let(:runner) { described_class.new }
-      let(:haml_path) { 'app/views/posts/show.html.haml' }
-      let(:haml_source) { "%p.title Hello\n= link_to 'x', posts_path" }
 
       context 'when Haml::VERSION is forced in the app environment' do
         let(:template) { "%p\n" }


### PR DESCRIPTION
Background / what changed
```
rails_best_practices turns view templates into Ruby before running its AST checks. 
For Haml it did that with Haml::Engine.new(template).precompiled, 
which matches Haml 5 (and older) where the template string is the first argument to initialize.

Haml 6+ switched to a Temple-style engine: Haml::Engine.new takes options, 
and the template is passed to #call. 
That matches how this gem already compiles Slim: Slim::Engine.new.call(content).

This change updates RailsBestPractices::Core::Runner so Haml compilation uses 
the right API for the Haml version actually loaded in the host app (or dev bundle),
not only whatever Haml version this repo pins for its own tests.
```

Issue
```
On Haml 6+ (e.g. 6.x / 7.x), Haml::Engine.new(content) is invalid
That raises at compile time; the analyzer treats the file as bad Ruby and  skips most .haml files,
so reviews that depend on parsed views (e.g. unused helpers) silently miss real usage.

Upgrading only this gem’s Gemfile / dev dependency to Haml 6 does not fix that for everyone: at runtime, 
the app’s resolved haml gem is what gets require 'haml'. 
Apps still on Haml 5 need the old path; apps on Haml 6+ need Engine.new.call(template).
```

Solution
```
Branch on Haml::VERSION:

≥ 6.0: Haml::Engine.new.call(template)
< 6.0: Haml::Engine.new(template).precompiled
(same post-step as before: strip \xxx escapes from the compiled string.) 
Use ::Gem::Version so version checks don’t resolve under RailsBestPractices::Core.
```

Tests: integration parse of a sample .haml on the bundled Haml, 
plus stubbed-version examples for the < 6 and ≥ 6 branches.